### PR TITLE
Add room application process

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,8 +108,7 @@ const policyservApi = new PolicyservApi(policyservBaseUrl, policyservApiKey);
 
             try {
                 // Actually approve the room
-                // await policyservApi.addRoom(policyservData["room_id"], policyservData["community_id"]);
-                await policyservApi.addRoom("!EqwjXrbedwInPOtMiv:t2l.io", policyservData["community_id"]);
+                await policyservApi.addRoom(policyservData["room_id"], policyservData["community_id"]);
 
                 // Send the notice
                 await client.sendHtmlNotice(policyservData["community_room_id"], `The application for the room <code>${escapeHtml(policyservData["room_id"])}</code> to join this community has been <b>approved</b>! The room will now be protected by policyserv.`);

--- a/src/policyserv_api.ts
+++ b/src/policyserv_api.ts
@@ -9,6 +9,34 @@ export class PolicyservApi {
         return community.community_id;
     }
 
+    public async getCommunity(communityId: string): Promise<CommunityResponse | null> {
+        try {
+            return await this.doRequest<CommunityResponse>("GET", `/api/v1/communities/${encodeURIComponent(communityId)}`);
+        } catch (e) {
+            if (e.status === 404) {
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    public async getRoom(roomId: string): Promise<RoomResponse | null> {
+        try {
+            return await this.doRequest<RoomResponse>("GET", `/api/v1/rooms/${encodeURIComponent(roomId)}`);
+        } catch (e) {
+            if (e.status === 404) {
+                return null;
+            }
+            throw e;
+        }
+    }
+
+    public async addRoom(roomId: string, communityId: string): Promise<void> {
+        await this.doRequest<void>("POST", `/api/v1/rooms/${encodeURIComponent(roomId)}/join`, {
+            community_id: communityId,
+        });
+    }
+
     private async doRequest<T>(method: string, path: string, body?: any): Promise<T> {
         const req = await fetch(this.baseUrl + path, {
             method: method,
@@ -19,7 +47,7 @@ export class PolicyservApi {
         });
         if (req.status !== 200) {
             const body = await req.text();
-            throw new Error(`Request (${path}) failed with status ${req.status}: ${body}`);
+            throw new HttpError(`Request (${path}) failed with status ${req.status}: ${body}`, req.status);
         }
         return await req.json();
     }
@@ -46,4 +74,18 @@ export interface CommunityConfig {
     hellban_postfilter_minutes?: number; // whole number, positive to enable
     mjolnir_filter_enabled?: boolean;
     spam_threshold?: number; // float
+}
+
+interface RoomResponse {
+    room_id: string;
+    room_version: string;
+    community_id: string;
+
+    // the other fields are not relevant to us
+}
+
+class HttpError extends Error {
+    constructor(message: string, public readonly status: number) {
+        super(message);
+    }
 }


### PR DESCRIPTION
Rough sequence:

1. Community created
2. `!policyserv apply #room:example.org`
3. Safety team approves/denies the room via reactions in the safety team room
4. If approved: Bot tries to set the appropriate state & manipulates the policyserv API 
5. Community is notified of the decision to approve/deny

Applications are entirely handled within the bot for now. When policyserv gains a UI, it'll probably be handled there. For now it's a bit too complicated to manage it in policyserv, so just don't for now.